### PR TITLE
Fixed spelling mistake in text for Pasemann

### DIFF
--- a/data.js
+++ b/data.js
@@ -98,7 +98,7 @@ var data = [
   {
     'forename': 'Frank',
     'name': 'Pasemann',
-    'text': ['der Kunde der Neonazi-Kleidermarke Thor Steinar ist', 'der Verbindungen zur rassistischen Identitäten Bewegungen hat'],
+    'text': ['der Kunde der Neonazi-Kleidermarke Thor Steinar ist', 'der Verbindungen zur rassistischen Identitären Bewegung hat'],
     'src': ['http://www.tagesspiegel.de/politik/neue-abgeordnete-das-sind-die-radikalen-in-der-afd-fraktion/20361302.html', 'http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete']
   },
   {


### PR DESCRIPTION
Fixed spelling mistake "Identitäten Bewegung" => "Identitäre Bewegung" for Frank Pasemann.
(Found by: Oliver Vanderb on the "Die PARTEI" facebook post - https://www.facebook.com/DiePARTEI/posts/1562113360491353)

Also changed "Bewegungen" to "Bewegung" (name of an organisation)