### PR TITLE
Limitation of extensions per person

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,6 +4,8 @@ const getRandomAddition = item => item.additions[Math.floor(item.additions.lengt
 
 const getNewString = (item, isEndOfSentence) => `${item.name}, ${getRandomAddition(item).text}${isEndOfSentence ? '' : ','}`;
 
+const MAX_OCCURRENCES = 5;
+
 // via http://stackoverflow.com/questions/10730309/find-all-text-nodes-in-html-page#answer-10730777
 function findTextNodes(el) {
   const textNodes = [];
@@ -20,13 +22,14 @@ function checkNames() {
 
 // extend text content with extension sentences
 function extendText() {
+  data.forEach(item => item.count = 0);
   findTextNodes(document.body).forEach(node => {
     node.textContent = node.textContent.replace(/Björn Höcke/g, 'Bernd Höcke');
     data.forEach(item => {
-      if (item.isPresent) {
+      if (item.isPresent && item.count < MAX_OCCURRENCES) {
         const parts = node.textContent.split(getNameRegex(item.name));
-        for (let i = parts.length - 1; i > 0; i--) {
-          const isEndOfSentence = /^\s*[^a-z 0-9]/i.test(parts[i]) || parts[i] === '';
+        for (let i = parts.length - 1; i > 0 && item.count < MAX_OCCURRENCES; i--, item.count++) {
+          const isEndOfSentence = /^\s*[^a-z 0-9]/i.test(parts[i]) || parts[i] === '';
           parts.splice(i, 0, getNewString(item, isEndOfSentence));
         }
         node.textContent = parts.join('');
@@ -37,4 +40,3 @@ function extendText() {
 
 checkNames();
 extendText();
-

--- a/content.js
+++ b/content.js
@@ -6,6 +6,8 @@ const getNewString = (item, isEndOfSentence) => `${item.name}, ${getRandomAdditi
 
 const MAX_OCCURRENCES = 5;
 
+const MAX_OCCURRENCES = 5;
+
 // via http://stackoverflow.com/questions/10730309/find-all-text-nodes-in-html-page#answer-10730777
 function findTextNodes(el) {
   const textNodes = [];

--- a/data.js
+++ b/data.js
@@ -2,544 +2,300 @@ var data = [
   {
     'forename': 'Björn',
     'name': 'Höcke',
-    'additions': [
-      {
-        'text': 'der gute Kontakte zur NPD hat',
-        'src': 'https://de.wikipedia.org/wiki/Bj%C3%B6rn_H%C3%B6cke#Vermutete_Autorschaft_in_Zeitschriften_des_NPD-Umfelds'
-      }
-    ]
+    'text': ['der gute Kontakte zur NPD hat'],
+    'src': ['https://de.wikipedia.org/wiki/Bj%C3%B6rn_H%C3%B6cke#Vermutete_Autorschaft_in_Zeitschriften_des_NPD-Umfelds']
   },
   {
     'forename': 'Alexander',
     'name': 'Gauland',
-    'additions': [
-      {
-        'text': 'der stolz auf die Leistungen deutscher Soldaten im zweiten Weltkrieg ist',
-        'src': 'https://www.buzzfeed.com/marcusengert/afd-spitzenkandidat-gauland-findet-deutsche-sollten-stolz?utm_term=.mdPMqlyw2v#.muP3gEdlzW'
-      },
-      {
-        'text': 'der Menschen entsorgen lassen will',
-        'src': 'http://www.faz.net/aktuell/politik/bundestagswahl/afd-alexander-gauland-traeumt-von-entsorgung-aydan-oezoguz-15171141.html'
-      }
-    ]
+    'text': ['der stolz auf die Leistungen deutscher Soldaten im zweiten Weltkrieg ist', 'der Menschen entsorgen lassen will'],
+    'src': ['https://www.buzzfeed.com/marcusengert/afd-spitzenkandidat-gauland-findet-deutsche-sollten-stolz?utm_term=.mdPMqlyw2v#.muP3gEdlzW', 'http://www.faz.net/aktuell/politik/bundestagswahl/afd-alexander-gauland-traeumt-von-entsorgung-aydan-oezoguz-15171141.html']
   },
   {
     'forename': 'Alice',
     'name': 'Weidel',
-    'additions': [
-      {
-        'text': 'die Deutschland als "nicht souverän" bezeichnet',
-        'src': 'http://www.zeit.de/politik/deutschland/2017-09/afd-spitzenkandidatin-alice-weidel-email-rechtsradikal'
-      }
-    ]
+    'text': ['die Deutschland als \"nicht souverän\" bezeichnet'],
+    'src': ['http://www.zeit.de/politik/deutschland/2017-09/afd-spitzenkandidatin-alice-weidel-email-rechtsradikal']
   },
   {
     'forename': 'Jörg',
     'name': 'Meuthen',
-    'additions': [
-      {
-        'text': 'der von einem "links-rot-grün verseuchten 68er-Deutschland" spricht',
-        'src': 'https://www.stuttgarter-nachrichten.de/inhalt.bundesparteitag-in-stuttgart-afd-will-den-bundespraesidenten-stellen.a4c235d3-4b5e-44fe-9bea-24f2befa986c.html'
-      }
-    ]
+    'text': ['der von einem \"links-rot-grün verseuchten 68er-Deutschland\" spricht'],
+    'src': ['https://www.stuttgarter-nachrichten.de/inhalt.bundesparteitag-in-stuttgart-afd-will-den-bundespraesidenten-stellen.a4c235d3-4b5e-44fe-9bea-24f2befa986c.html']
   },
   {
     'forename': 'Jens',
     'name': 'Maier',
-    'additions': [
-      {
-        'text': 'der Verständnis für den Massenmörder Anders Breivik gezeigt hat',
-        'src': 'http://www.tagesspiegel.de/politik/jens-maier-aus-sachsen-afd-politiker-aeussert-verstaendnis-fuer-rechtsterrorist-anders-breivik/19698996.html'
-      }
-    ]
+    'text': ['der Verständnis für den Massenmörder Anders Breivik gezeigt hat'],
+    'src': ['http://www.tagesspiegel.de/politik/jens-maier-aus-sachsen-afd-politiker-aeussert-verstaendnis-fuer-rechtsterrorist-anders-breivik/19698996.html']
   },
   {
     'forename': 'Frauke',
     'name': 'Petry',
-    'additions': [
-      {
-        'text': 'die Fan der französischen Rechtsextremistin Marine Le Pen ist',
-        'src': 'https://de.wikipedia.org/wiki/Frauke_Petry#Migrationspolitik,_Asylrecht,_Kriminalit%C3%A4tsbek%C3%A4mpfung_und_EU'
-      },
-      {
-        'text': 'die den Schießbefehl an der Grenze fordert',
-        'src': 'http://www.faz.net/aktuell/politik/inland/afd-chefin-frauke-petry-fodert-schiessbefehl-an-grenze-14044672.html'
-      }
-    ]
+    'text': ['die Fan der französischen Rechtsextremistin Marine Le Pen ist', 'die den Schießbefehl an der Grenze fordert'],
+    'src': ['https://de.wikipedia.org/wiki/Frauke_Petry#Migrationspolitik,_Asylrecht,_Kriminalit%C3%A4tsbek%C3%A4mpfung_und_EU', 'http://www.faz.net/aktuell/politik/inland/afd-chefin-frauke-petry-fodert-schiessbefehl-an-grenze-14044672.html']
   },
   {
     'forename': 'Horst',
     'name': 'Seehofer',
-    'additions': [
-      {
-        'text': 'der im Bundestag dagegen gestimmt hat, Vergewaltigung in der Ehe unter Strafe zu stellen',
-        'src': 'https://twitter.com/renatekuenast/status/685743903442624512?lang=de'
-      }
-    ]
+    'text': ['der im Bundestag dagegen gestimmt hat, Vergewaltigung in der Ehe unter Strafe zu stellen'],
+    'src': ['https://twitter.com/renatekuenast/status/685743903442624512?lang=de']
   },
   {
     'forename': 'Manfred',
     'name': 'Weber',
-    'additions': [
-      {
-        'text': 'der von der "finalen Lösung der Flüchtlingsfrage" gesprochen hat',
-        'src': 'http://www.spiegel.de/politik/deutschland/manfred-weber-fordert-die-finale-loesung-der-fluechtlingsfrage-a-1186493.html'
-      }
-    ]
+    'text': ['der von der \"finalen Lösung der Flüchtlingsfrage\" gesprochen hat'],
+    'src': ['http://www.spiegel.de/politik/deutschland/manfred-weber-fordert-die-finale-loesung-der-fluechtlingsfrage-a-1186493.html']
   },
   {
     'forename': 'Volker',
     'name': 'Kauder',
-    'additions': [
-      {
-        'text': 'der im Bundestag gegen die Strafbarkeit von Vergewaltigung in der Ehe gestimmt hat',
-        'src': 'https://twitter.com/renatekuenast/status/685743903442624512?lang=de'
-      }
-    ]
+    'text': ['der im Bundestag gegen die Strafbarkeit von Vergewaltigung in der Ehe gestimmt hat'],
+    'src': ['https://twitter.com/renatekuenast/status/685743903442624512?lang=de']
   },
   {
     'forename': 'Albrecht',
     'name': 'Glaser',
-    'additions': [
-      {
-        'text': 'der das Grundrecht auf Religionsfreiheit abschaffen will',
-        'src': 'https://de.wikipedia.org/wiki/Albrecht_Glaser'
-      }
-    ]
+    'text': ['der das Grundrecht auf Religionsfreiheit abschaffen will'],
+    'src': ['https://de.wikipedia.org/wiki/Albrecht_Glaser']
   },
   {
     'forename': 'Kay',
     'name': 'Nerstheimer',
-    'additions': [
-      {
-        'text': 'der Homosexuelle als "degenierte Spezies" bezeichnet',
-        'src': 'https://www.neues-deutschland.de/artikel/1070234.afd-im-abgeordnetenhaus-verschwoerung-und-hass.html'
-      }
-    ]
+    'text': ['der Homosexuelle als \"degenierte Spezies\" bezeichnet'],
+    'src': ['https://www.neues-deutschland.de/artikel/1070234.afd-im-abgeordnetenhaus-verschwoerung-und-hass.html']
   },
   {
     'forename': 'Georg',
     'name': 'Pazderski',
-    'additions': [
-      {
-        'text': 'der vom "Volkssturm der Argumente" spricht',
-        'src': 'https://www.neues-deutschland.de/artikel/1070234.afd-im-abgeordnetenhaus-verschwoerung-und-hass.html'
-      }
-    ]
+    'text': ['der vom \"Volkssturm der Argumente\" spricht'],
+    'src': ['https://www.neues-deutschland.de/artikel/1070234.afd-im-abgeordnetenhaus-verschwoerung-und-hass.html']
   },
   {
     'forename': 'Markus',
     'name': 'Frohnmaier',
-    'additions': [
-      {
-        'text': 'der "volksfeindliche Parteien" aus Deutschland "heraustreiben will"',
-        'src': 'http://meedia.de/2017/05/10/zitate-streit-afd-politiker-markus-frohnmaier-verliert-vor-gericht-gegen-ulmer-lokal-portal/'
-      },
-      {
-        'text': 'der mit rechtsextremen Organisationen zusammenarbeitet',
-        'src': 'http://www.badische-zeitung.de/suedwest-1/neue-vorwuerfe-gegen-afd-jungpolitiker-frohnmaier--125381174.html'
-      }
-    ]
+    'text': ['der \"volksfeindliche Parteien\" aus Deutschland \"heraustreiben will\"', 'der mit rechtsextremen Organisationen zusammenarbeitet'],
+    'src': ['http://meedia.de/2017/05/10/zitate-streit-afd-politiker-markus-frohnmaier-verliert-vor-gericht-gegen-ulmer-lokal-portal/', 'http://www.badische-zeitung.de/suedwest-1/neue-vorwuerfe-gegen-afd-jungpolitiker-frohnmaier--125381174.html']
   },
   {
     'forename': 'Martin',
     'name': 'Hohmann',
-    'additions': [
-      {
-        'text': 'der Juden als Tätervolk bezeichnet',
-        'src': 'http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete'
-      }
-    ]
+    'text': ['der Juden als Tätervolk bezeichnet'],
+    'src': ['http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete']
   },
   {
     'forename': 'Wilhelm',
     'name': 'von Gottberg',
-    'additions': [
-      {
-        'text': 'der den Holocaust als "Mittel zur Kriminalisierung der Deutschen" bezeichnet',
-        'src': 'http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete'
-      }
-    ]
+    'text': ['der den Holocaust als \"Mittel zur Kriminalisierung der Deutschen\" bezeichnet'],
+    'src': ['http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete']
   },
   {
     'forename': 'Stefan',
     'name': 'Keuter',
-    'additions': [
-      {
-        'text': 'der auf Pegida-Demos "Lügenpresse" mitskandiert',
-        'src': 'http://www.tagesspiegel.de/politik/neue-abgeordnete-das-sind-die-radikalen-in-der-afd-fraktion/20361302.html'
-      }
-    ]
+    'text': ['der auf Pegida-Demos \"Lügenpresse\" mitskandiert'],
+    'src': ['http://www.tagesspiegel.de/politik/neue-abgeordnete-das-sind-die-radikalen-in-der-afd-fraktion/20361302.html']
   },
   {
     'forename': 'Frank',
     'name': 'Pasemann',
-    'additions': [
-      {
-        'text': 'der Kunde der Neonazi-Kleidermarke Thor Steinar ist',
-        'src': 'http://www.tagesspiegel.de/politik/neue-abgeordnete-das-sind-die-radikalen-in-der-afd-fraktion/20361302.html'
-      },
-      {
-        'text': 'der Verbindungen zur rassistischen Identitären Bewegung hat',
-        'src': 'http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete'
-      }
-    ]
+    'text': ['der Kunde der Neonazi-Kleidermarke Thor Steinar ist', 'der Verbindungen zur rassistischen Identitären Bewegung hat'],
+    'src': ['http://www.tagesspiegel.de/politik/neue-abgeordnete-das-sind-die-radikalen-in-der-afd-fraktion/20361302.html', 'http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete']
   },
   {
     'forename': 'Petr',
     'name': 'Bystron',
-    'additions': [
-      {
-        'text': 'der laut einem Münchner Gericht verfassungsfeindliche Bestrebungen zeigt',
-        'src': 'http://www.tagesspiegel.de/politik/neue-abgeordnete-das-sind-die-radikalen-in-der-afd-fraktion/20361302.html'
-      }
-    ]
+    'text': ['der laut einem Münchner Gericht verfassungsfeindliche Bestrebungen zeigt'],
+    'src': ['http://www.tagesspiegel.de/politik/neue-abgeordnete-das-sind-die-radikalen-in-der-afd-fraktion/20361302.html']
   },
   {
     'forename': 'Beatrix',
     'name': 'von Storch',
-    'additions': [
-      {
-        'text': 'die an der Grenze auch auf Kinder schießen lassen würde',
-        'src': 'http://www.spiegel.de/politik/deutschland/afd-beatrix-von-storch-wird-im-netz-verspottet-a-1076209.html'
-      }
-    ]
+    'text': ['die an der Grenze auch auf Kinder schießen lassen würde'],
+    'src': ['http://www.spiegel.de/politik/deutschland/afd-beatrix-von-storch-wird-im-netz-verspottet-a-1076209.html']
   },
   {
     'forename': 'Andreas',
     'name': 'Kalbitz',
-    'additions': [
-      {
-        'text': 'der Vorsitzender des rechtsextremen Vereins Kultur- und Zeitgeschichte, Archiv der Zeit war',
-        'src': 'http://www.maz-online.de/Brandenburg/Der-Brandenburger-AfD-Landtagsabgeordnete-Andreas-Kalbitz-geraet-wegen-einer-Mitgliedschaft-in-einem-rechten-Verein-unter-Druck'
-      }
-    ]
+    'text': ['der Vorsitzender des rechtsextremen Vereins Kultur- und Zeitgeschichte, Archiv der Zeit war'],
+    'src': ['http://www.maz-online.de/Brandenburg/Der-Brandenburger-AfD-Landtagsabgeordnete-Andreas-Kalbitz-geraet-wegen-einer-Mitgliedschaft-in-einem-rechten-Verein-unter-Druck']
   },
   {
     'forename': 'Doris',
     'name': 'von Sayn-Wittgenstein',
-    'additions': [
-      {
-        'text': 'die im Vorstand eines Reichsbürger-Vereins war',
-        'src': 'http://haz.de/Nachrichten/Politik/Deutschland-Welt/AfD-Fuerstin-hat-Vergangenheit-in-Reichsbuerger-Szene'
-      }
-    ]
+    'text': ['die im Vorstand eines Reichsbürger-Vereins war'],
+    'src': ['http://haz.de/Nachrichten/Politik/Deutschland-Welt/AfD-Fuerstin-hat-Vergangenheit-in-Reichsbuerger-Szene']
   },
   {
     'forename': 'André',
     'name': 'Poggenburg',
-    'additions': [
-      {
-        'text': 'der Veranstaltungen mit Neonazis durchführt',
-        'src': 'http://www.zeit.de/2016/05/afd-andre-poggenburg-sachsen-anhalt-asylpolitik-wahlkampf'
-      }
-    ]
+    'text': ['der Veranstaltungen mit Neonazis durchführt'],
+    'src': ['http://www.zeit.de/2016/05/afd-andre-poggenburg-sachsen-anhalt-asylpolitik-wahlkampf']
   },
   {
     'forename': 'Uwe',
     'name': 'Junge',
-    'additions': [
-      {
-        'text': 'der Fan von Viktor Orbán ist',
-        'src': 'https://twitter.com/Uwe_Junge_MdL/status/950625041775022080'
-      }
-    ]
+    'text': ['der Fan von Viktor Orbán ist'],
+    'src': ['https://twitter.com/Uwe_Junge_MdL/status/950625041775022080']
   },
   {
     'forename': 'Marc',
     'name': 'Jongen',
-    'additions': [
-      {
-        'text': 'der Verschwörungstheorien zu "Mischbevölkerungen" zitiert',
-        'src': 'http://www.sueddeutsche.de/politik/philosoph-marc-jongen-der-wutdenker-der-afd-1.2865813-2'
-      }
-    ]
+    'text': ['der Verschwörungstheorien zu \"Mischbevölkerungen\" zitiert'],
+    'src': ['http://www.sueddeutsche.de/politik/philosoph-marc-jongen-der-wutdenker-der-afd-1.2865813-2']
   },
   {
     'forename': 'Guido',
     'name': 'Reil',
-    'additions': [
-      {
-        'text': 'der eng mit Bernd Höcke zusammenarbeit',
-        'src': 'https://twitter.com/GuidoReil/status/952712254868377606'
-      }
-    ]
+    'text': ['der eng mit Bernd Höcke zusammenarbeit'],
+    'src': ['https://twitter.com/GuidoReil/status/952712254868377606']
   },
   {
     'forename': 'Ralf',
     'name': 'Özkara',
-    'additions': [
-      {
-        'text': 'der die Überwachung aller Moscheen in Deutschland fordert',
-        'src': 'https://www.youtube.com/watch?v=0_XCeFgZHQk'
-      }
-    ]
+    'text': ['der die Überwachung aller Moscheen in Deutschland fordert'],
+    'src': ['https://www.youtube.com/watch?v=0_XCeFgZHQk']
   },
   {
     'forename': 'Martin',
     'name': 'Sichert',
-    'additions': [
-      {
-        'text': 'der den zweiten Weltkrieg verharmlost',
-        'src': 'http://www.abendzeitung-muenchen.de/inhalt.sie-ziehen-in-den-bundestag-ein-die-kuenftigen-bayerischen-afd-abgeordneten.b36878c1-9162-404d-80ab-f89021b4d36c.html'
-      }
-    ]
+    'text': ['der den zweiten Weltkrieg verharmlost'],
+    'src': ['http://www.abendzeitung-muenchen.de/inhalt.sie-ziehen-in-den-bundestag-ein-die-kuenftigen-bayerischen-afd-abgeordneten.b36878c1-9162-404d-80ab-f89021b4d36c.html']
   },
   {
     'forename': 'Frank',
     'name': 'Magnitz',
-    'additions': [
-      {
-        'text': 'der eng mit Bernd Höcke zusammenarbeitet',
-        'src': 'https://www.weser-kurier.de/bremen/bremen-stadt_artikel,-gegen-merkel-und-mohammed-_arid,1645275.html'
-      }
-    ]
+    'text': ['der eng mit Bernd Höcke zusammenarbeitet'],
+    'src': ['https://www.weser-kurier.de/bremen/bremen-stadt_artikel,-gegen-merkel-und-mohammed-_arid,1645275.html']
   },
   {
     'forename': 'Dirk',
     'name': 'Nockemann',
-    'additions': [
-      {
-        'text': 'der für eine Wasserwerfer-Attacke auf die Holocaust-Überlebende Esther Bejarano verantwortlich ist',
-        'src': 'https://publikative.org/2015/01/17/schill-imitator-bei-der-afd-in-hamburg/'
-      }
-    ]
+    'text': ['der für eine Wasserwerfer-Attacke auf die Holocaust-Überlebende Esther Bejarano verantwortlich ist'],
+    'src': ['https://publikative.org/2015/01/17/schill-imitator-bei-der-afd-in-hamburg/']
   },
   {
     'forename': 'Leif-Erik',
     'name': 'Holm',
-    'additions': [
-      {
-        'text': 'der mit Bernd Höcke zusammenarbeitet',
-        'src': 'http://www.zeit.de/2016/37/mecklenburg-vorpommern-afd-kandidat-leif-erik-holm-berlin'
-      }
-    ]
+    'text': ['der mit Bernd Höcke zusammenarbeitet'],
+    'src': ['http://www.zeit.de/2016/37/mecklenburg-vorpommern-afd-kandidat-leif-erik-holm-berlin']
   },
   {
     'forename': 'Armin-Paul',
     'name': 'Hampel',
-    'additions': [
-      {
-        'text': 'der von "Asylwahn" und "Blockparteien" im Bundestag spricht',
-        'src': 'https://www.taz.de/!5241266/'
-      }
-    ]
+    'text': ['der von \"Asylwahn\" und \"Blockparteien\" im Bundestag spricht'],
+    'src': ['https://www.taz.de/!5241266/']
   },
   {
     'forename': 'Thomas',
     'name': 'Röckemann',
-    'additions': [
-      {
-        'text': 'der von "Systemmedien" spricht',
-        'src': 'https://de-de.facebook.com/thomas.roeckemann/posts/1272919946186671'
-      }
-    ]
+    'text': ['der von \"Systemmedien\" spricht'],
+    'src': ['https://de-de.facebook.com/thomas.roeckemann/posts/1272919946186671']
   },
   {
     'forename': 'Jürgen',
     'name': 'Pohl',
-    'additions': [
-      {
-        'text': 'der mit zahlreichen Nazis auf Facebook befreundet ist',
-        'src': 'https://www.buzzfeed.com/marcusengert/fast-50-bundestagskandidaten-der-afd-grenzen-sich-nicht-von?utm_term=.puYAXweYRB#.xgj8G3xb7r'
-      },
-      {
-        'text': 'der enger Weggefährte von Bernd Höcke ist',
-        'src': 'https://de.wikipedia.org/wiki/J%C3%BCrgen_Pohl_(Politiker)'
-      }
-    ]
+    'text': ['der mit zahlreichen Nazis auf Facebook befreundet ist', 'der enger Weggefährte von Bernd Höcke ist'],
+    'src': ['https://www.buzzfeed.com/marcusengert/fast-50-bundestagskandidaten-der-afd-grenzen-sich-nicht-von?utm_term=.puYAXweYRB#.xgj8G3xb7r', 'https://de.wikipedia.org/wiki/J%C3%BCrgen_Pohl_(Politiker)']
   },
   {
     'forename': 'Thomas',
     'name': 'Seitz',
-    'additions': [
-      {
-        'text': 'der Rassist ist',
-        'src': 'http://www.spiegel.de/wissenschaft/mensch/bundestagswahl-2017-sieben-gruende-afd-zu-waehlen-aber-treffen-sie-auf-sie-zu-a-1169258.html'
-      }
-    ]
+    'text': ['der Rassist ist'],
+    'src': ['http://www.spiegel.de/wissenschaft/mensch/bundestagswahl-2017-sieben-gruende-afd-zu-waehlen-aber-treffen-sie-auf-sie-zu-a-1169258.html']
   },
   {
     'forename': 'Peter',
     'name': 'Boehringer',
-    'additions': [
-      {
-        'text': 'der an eine jüdische Weltverschwörung glaubt',
-        'src': 'http://www.tagesspiegel.de/politik/gaulands-mitstreiter-diese-rechten-will-die-afd-in-den-bundestag-schicken/20344126.html'
-      },
-      {
-        'text': 'der die Kanzlerin als "Merkelnutte" bezeichnet haben soll',
-        'src': 'http://www.spiegel.de/politik/deutschland/bundestag-wann-die-afd-beim-gedenken-an-auschwitz-befreiung-nicht-klatschte-a-1190774.html'
-      }
-    ]
+    'text': ['der an eine jüdische Weltverschwörung glaubt', 'der die Kanzlerin als \"Merkelnutte\" bezeichnet haben soll'],
+    'src': ['http://www.tagesspiegel.de/politik/gaulands-mitstreiter-diese-rechten-will-die-afd-in-den-bundestag-schicken/20344126.html', 'http://www.spiegel.de/politik/deutschland/bundestag-wann-die-afd-beim-gedenken-an-auschwitz-befreiung-nicht-klatschte-a-1190774.html']
   },
   {
     'forename': 'Enrico',
     'name': 'Komning',
-    'additions': [
-      {
-        'text': 'der mit seiner Tochter stolz die erste Strophe der Nationalhymne singt',
-        'src': 'http://www.tagesspiegel.de/themen/reportage/rechte-vor-einzug-in-den-bundestag-so-extrem-sind-die-kandidaten-der-afd/20350578.html'
-      },
-      {
-        'text': 'der mit der rechtsextremen Identitären Bewegung und mit Pegida sympathisiert',
-        'src': 'http://www.belltower.news/artikel/afd-vor-den-wahlen-das-schreiben-die-kandidatinnen-bei-facebook-und-twitter-11193'
-      }
-    ]
+    'text': ['der mit seiner Tochter stolz die erste Strophe der Nationalhymne singt', 'der mit der rechtsextremen Identitären Bewegung und mit Pegida sympathisiert'],
+    'src': ['http://www.tagesspiegel.de/themen/reportage/rechte-vor-einzug-in-den-bundestag-so-extrem-sind-die-kandidaten-der-afd/20350578.html', 'http://www.belltower.news/artikel/afd-vor-den-wahlen-das-schreiben-die-kandidatinnen-bei-facebook-und-twitter-11193']
   },
   {
     'forename': 'Sebastian',
     'name': 'Münzenmaier',
-    'additions': [
-      {
-        'text': 'der an Hooligan-Schlägereien teilgenommen haben soll',
-        'src': 'http://www.tagesspiegel.de/themen/reportage/rechte-vor-einzug-in-den-bundestag-so-extrem-sind-die-kandidaten-der-afd/20350578.html'
-      },
-      {
-        'text': 'der Mitglied bei der islamfeindlichen Partei "Die Freiheit" war'
-      }
-    ]
+    'text': ['der an Hooligan-Schlägereien teilgenommen haben soll', 'der Mitglied bei der islamfeindlichen Partei \"Die Freiheit\" war'],
+    'src': ['http://www.tagesspiegel.de/themen/reportage/rechte-vor-einzug-in-den-bundestag-so-extrem-sind-die-kandidaten-der-afd/20350578.html']
   },
   {
     'forename': 'Nicolaus',
     'name': 'Fest',
-    'additions': [
-      {
-        'text': 'der Gastarbeiter als "Gesindel" bezeichnet',
-        'src': 'http://www.tagesspiegel.de/berlin/afd-bundestagskandidat-anzeige-gegen-nicolaus-fest-wegen-volksverhetzung/19600292.html'
-      },
-      {
-        'text': 'der alle Moscheen in Deutschland schließen lassen will',
-        'src': 'http://www.spiegel.de/video/afd-neuzugang-nicolaus-fest-will-schliessung-von-moscheen-video-1710365.html'
-      }
-    ]
+    'text': ['der Gastarbeiter als \"Gesindel\" bezeichnet', 'der alle Moscheen in Deutschland schließen lassen will'],
+    'src': ['http://www.tagesspiegel.de/berlin/afd-bundestagskandidat-anzeige-gegen-nicolaus-fest-wegen-volksverhetzung/19600292.html', 'http://www.spiegel.de/video/afd-neuzugang-nicolaus-fest-will-schliessung-von-moscheen-video-1710365.html']
   },
   {
     'forename': 'Karsten',
     'name': 'Hilse',
-    'additions': [
-      {
-        'text': 'der hinter der Ehe für alle "Strippenzieher im Hintergrund" vermutet',
-        'src': 'http://www.tagesspiegel.de/themen/reportage/rechte-vor-einzug-in-den-bundestag-so-extrem-sind-die-kandidaten-der-afd/20350578.html'
-      }
-    ]
+    'text': ['der hinter der Ehe für alle \"Strippenzieher im Hintergrund\" vermutet'],
+    'src': ['http://www.tagesspiegel.de/themen/reportage/rechte-vor-einzug-in-den-bundestag-so-extrem-sind-die-kandidaten-der-afd/20350578.html']
   },
   {
     'forename': 'Tino',
     'name': 'Chrupalla',
-    'additions': [
-      {
-        'text': 'der die Zensur von Medien fordert',
-        'src': 'http://www.bento.de/politik/afd-dutzende-rechtsradikale-auf-den-vorderen-listenplaetze-zur-bundestagswahl-2017-1681100/'
-      }
-    ]
+    'text': ['der die Zensur von Medien fordert'],
+    'src': ['http://www.bento.de/politik/afd-dutzende-rechtsradikale-auf-den-vorderen-listenplaetze-zur-bundestagswahl-2017-1681100/']
   },
   {
     'forename': 'Martin',
     'name': 'Renner',
-    'additions': [
-      {
-        'text': 'der von einer "Schuldkult-Hypermoralisierung" in Deutschland spricht',
-        'src': 'http://www.rundschau-online.de/politik/rechtsruck-bei-der-afd-martin-renner-wird-spitzenkandidat-fuer-die-bundestagswahl-25918682'
-      }
-    ]
+    'text': ['der von einer \"Schuldkult-Hypermoralisierung\" in Deutschland spricht'],
+    'src': ['http://www.rundschau-online.de/politik/rechtsruck-bei-der-afd-martin-renner-wird-spitzenkandidat-fuer-die-bundestagswahl-25918682']
   },
   {
     'forename': 'Siegbert',
     'name': 'Droese',
-    'additions': [
-      {
-        'text': 'dessen Autokennzeichen die Neonazicodes AH1818 enthält',
-        'src': 'https://www.vice.com/de/article/mv4mbn/die-afd-faehrt-mit-hitler-kennzeichen-durch-leipzig'
-      },
-      {
-        'text': 'der mit der Rechtsextremen Tatjana Festerling bei Legida zusammenarbeiten wollte',
-        'src': 'https://kreuzer-leipzig.de/2016/05/24/wie-viel-pegida-partei-will-die-afd-sein/'
-      }
-    ]
+    'text': ['dessen Autokennzeichen die Neonazicodes AH1818 enthält', 'der mit der Rechtsextremen Tatjana Festerling bei Legida zusammenarbeiten wollte'],
+    'src': ['https://www.vice.com/de/article/mv4mbn/die-afd-faehrt-mit-hitler-kennzeichen-durch-leipzig', 'https://kreuzer-leipzig.de/2016/05/24/wie-viel-pegida-partei-will-die-afd-sein/']
   },
   {
     'forename': 'Stefan',
     'name': 'Kotré',
-    'additions': [
-      {
-        'text': 'laut dem Herkunft und "Vergewaltigerpotenzial" direkt zusammenhängen',
-        'src': 'http://www.berliner-zeitung.de/berlin/die-abgeordneten-der-afd-sammelbecken-der-unzufriedenen-221000'
-      }
-    ]
+    'text': ['laut dem Herkunft und \"Vergewaltigerpotenzial\" direkt zusammenhängen'],
+    'src': ['http://www.berliner-zeitung.de/berlin/die-abgeordneten-der-afd-sammelbecken-der-unzufriedenen-221000']
   },
   {
     'forename': 'Detlef',
     'name': 'Spangenberg',
-    'additions': [
-      {
-        'text': 'der Mitglied der rechtsextremen Wählervereinigung "Arbeit, Familie, Vaterland" war',
-        'src': 'http://www.spiegel.de/politik/deutschland/afd-in-sachsen-kein-amt-fuer-abgeordneten-mit-rechter-vergangenheit-a-989731.html'
-      }
-    ]
+    'text': ['der Mitglied der rechtsextremen Wählervereinigung \"Arbeit, Familie, Vaterland\" war'],
+    'src': ['http://www.spiegel.de/politik/deutschland/afd-in-sachsen-kein-amt-fuer-abgeordneten-mit-rechter-vergangenheit-a-989731.html']
   },
   {
     'forename': 'Ulrich',
     'name': 'Oehme',
-    'additions': [
-      {
-        'text': 'der mit einem SA-Spruch zur Bundestagswahl geworben hatte',
-        'src': 'http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete'
-      }
-    ]
+    'text': ['der mit einem SA-Spruch zur Bundestagswahl geworben hatte'],
+    'src': ['http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete']
   },
   {
     'forename': 'Hans-Jörg',
     'name': 'Müller',
-    'additions': [
-      {
-        'text': 'der Migration nach Deutschland als "organisierte Invasion" bezeichnet',
-        'src': 'https://www.youtube.com/watch?time_continue=2&v=pI03Ar7SmkA'
-      }
-    ]
+    'text': ['der Migration nach Deutschland als \"organisierte Invasion\" bezeichnet'],
+    'src': ['https://www.youtube.com/watch?time_continue=2&v=pI03Ar7SmkA']
   },
   {
     'forename': 'Heiko',
     'name': 'Hessenkemper',
-    'additions': [
-      {
-        'text': 'der ultrarechts ist',
-        'src': 'http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete'
-      }
-    ]
+    'text': ['der ultrarechts ist'],
+    'src': ['http://www.zeit.de/politik/deutschland/2017-09/afd-kandidaten-bundestagswahl-abgeordnete']
   },
   {
     'forename': 'Stephan',
     'name': 'Brandner',
-    'additions': [
-      {
-        'text': 'der politische Gegner als "Ergebnis von Sodomie und Inzucht" bezeichnet',
-        'src': 'https://www.noz.de/deutschland-welt/politik/artikel/955751/wie-rechts-ist-die-afd'
-      }
-    ]
+    'text': ['der politische Gegner als \"Ergebnis von Sodomie und Inzucht\" bezeichnet'],
+    'src': ['https://www.noz.de/deutschland-welt/politik/artikel/955751/wie-rechts-ist-die-afd']
   },
   {
     'forename': 'Kay',
     'name': 'Gottschalk',
-    'additions': [
-      {
-        'text': 'der dazu aufrief, türkische Geschäfte zu boykottieren',
-        'src': 'http://www.rp-online.de/nrw/staedte/krefeld/krefeld-kay-gottschalk-afd-ruft-zu-boykott-tuerkischer-geschaefte-auf-aid-1.7345603'
-      }
-    ]
+    'text': ['der dazu aufrief, türkische Geschäfte zu boykottieren'],
+    'src': ['http://www.rp-online.de/nrw/staedte/krefeld/krefeld-kay-gottschalk-afd-ruft-zu-boykott-tuerkischer-geschaefte-auf-aid-1.7345603']
   },
   {
     'forename': 'Nikolaus',
     'name': 'Kramer',
-    'additions': [
-      {
-        'text': 'der die SS-Leibstandarte Adolf Hitler "nicht grundsätzlich scheiße" findet',
-        'src': 'https://www.ndr.de/nachrichten/mecklenburg-vorpommern/Fragwuerdiges-SS-Foto-in-AfD-Chat-verschickt,afd1592.html'
-      },
-      {
-        'text': 'der Frauen für weniger geeignet für die Politik hält als Männer hält',
-        'src': 'https://www.ndr.de/nachrichten/mecklenburg-vorpommern/AfD-Fraktionschef-Maenner-eher-fuer-Politik-gemacht,afd1516.html'
-      }
-    ]
-  }
-];
+    'text': ['der die SS-Leibstandarte Adolf Hitler \"nicht grundsätzlich scheiße\" findet', 'der Frauen für weniger geeignet für die Politik hält als Männer hält'],
+    'src': ['https://www.ndr.de/nachrichten/mecklenburg-vorpommern/Fragwuerdiges-SS-Foto-in-AfD-Chat-verschickt,afd1592.html', 'https://www.ndr.de/nachrichten/mecklenburg-vorpommern/AfD-Fraktionschef-Maenner-eher-fuer-Politik-gemacht,afd1516.html']
+  }];


### PR DESCRIPTION
Fixes #22 
Currently, the number of extensions per name is hardcoded to 5. Should be adjustable in some kind of options menu.